### PR TITLE
FreeBSD Compatibility Patch pt. 1

### DIFF
--- a/kjv.sh
+++ b/kjv.sh
@@ -5,7 +5,7 @@
 SELF="$0"
 
 get_data() {
-	sed '1,/^#EOF$/d' < "$SELF" | tar xz -O "$1"
+	sed '1,/^#EOF$/d' < "$SELF" | tar xzf - -O "$1"
 }
 
 if [ -z "$PAGER" ]; then


### PR DESCRIPTION
Explicitly set tar output file to standard.

Works in Manjaro Linux. Changes no operations. Fixes for FreeBSD. Win, win.