### PR TITLE
FreeBSD Compatibility Patch pt. 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ kjv: kjv.sh kjv.awk kjv.tsv
 	cat kjv.sh > $@
 	echo 'exit 0' >> $@
 	echo '#EOF' >> $@
-	tar cz kjv.awk kjv.tsv >> $@
+	tar czf - kjv.awk kjv.tsv >> $@
 	chmod +x $@
 
 test: kjv.sh


### PR DESCRIPTION
Explicitly set tar output file to standard.

Works in Manjaro Linux. Changes no operations. Fixes for FreeBSD. Win, win. 

(2 pull requests made because 1 would not work with this repo)